### PR TITLE
Upgrade gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ Temporary Items
 *.dvi
 
 # Files created by latex
-.bbl
-.blg
+*.bbl
+*.blg

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ Temporary Items
 *.log
 *.gz
 *.dvi
+
+# Files created by latex
+.bbl
+.blg


### PR DESCRIPTION
I found that there could be created `.bbl` and `.blg` files when running latex on `examples.tex`. Now these will not show up in git.